### PR TITLE
chore: add shared contract frontend sanity import

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ CITIESair frontend communicates with CITIESair backend server via RestAPI for:
 - POST/EDIT/DELETE: CRUD operations for alerts and email subscribers
 The full list of API endpoints is documented in [API Documentation]()
 
+## Shared API Contracts
+
+The frontend can import shared ts-rest contracts from `@citiesair/shared/contracts`. This repo currently includes only a sanity integration; no React components have been migrated to contract-driven API calls yet.
+
+Backend endpoints currently covered by shared contracts are `GET /current/:school`, `GET /current/:school/:location_short`, `GET /school_metadata/:school`, and `GET /screen/:school/:screen_name`.
+
 CITIESair frontend is hosted on GitHub Pages. [Section 2.4](#24-deployment-process) explains how the deployment process works.
 
 There are quite a lot of overlapping components between CITIESair and CITIES Dashboard (as Air Quality used to be a dataset within the much bigger CITIES Dashboard). The CITIES Dashboard repo with documentation can be found [here](https://github.com/CITIES-Dashboard/cities-dashboard.github.io).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "citiesair",
       "version": "1.0.0",
       "dependencies": {
+        "@citiesair/shared": "git+ssh://git@github.com/CITIESair/citiesair-types-and-business-domain.git#2cdbf8f9b0c3355cdd79d46418ec99e169a858a3",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mui/icons-material": "^5.14.11",
@@ -20,6 +21,7 @@
         "@tanstack/query-async-storage-persister": "^5.90.7",
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-query-persist-client": "^5.90.7",
+        "@ts-rest/core": "^3.52.1",
         "d3": "^7.8.5",
         "date-fns": "^3.6.0",
         "dayjs": "^1.11.9",
@@ -44,7 +46,8 @@
         "react-qr-code": "^2.0.12",
         "react-router-dom": "^6.21.3",
         "react-transition-group": "^4.4.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
@@ -347,6 +350,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@citiesair/shared": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/CITIESair/citiesair-types-and-business-domain.git#2cdbf8f9b0c3355cdd79d46418ec99e169a858a3",
+      "integrity": "sha512-gI5uN+cUd4J5kJ/wdgWhd4FAsoXGu00KBb876dohrTZI6DDwrIWWQCgSfKa6ldDoDA8M7g/cbi6BsddAj/h8HQ==",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@ts-rest/core": "^3.52.1",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2279,6 +2294,24 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.12",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@ts-rest/core": {
+      "version": "3.52.1",
+      "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.52.1.tgz",
+      "integrity": "sha512-tAjz7Kxq/grJodcTA1Anop4AVRDlD40fkksEV5Mmal88VoZeRKAG8oMHsDwdwPZz+B/zgnz0q2sF+cm5M7Bc7g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/node": "^18.18.7 || >=20.8.4",
+        "zod": "^3.22.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/babel__core": {
@@ -8332,6 +8365,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@citiesair/shared": "git+ssh://git@github.com/CITIESair/citiesair-types-and-business-domain.git#2cdbf8f9b0c3355cdd79d46418ec99e169a858a3",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.14.11",
@@ -16,6 +17,7 @@
     "@tanstack/query-async-storage-persister": "^5.90.7",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-persist-client": "^5.90.7",
+    "@ts-rest/core": "^3.52.1",
     "d3": "^7.8.5",
     "date-fns": "^3.6.0",
     "dayjs": "^1.11.9",
@@ -40,7 +42,8 @@
     "react-qr-code": "^2.0.12",
     "react-router-dom": "^6.21.3",
     "react-transition-group": "^4.4.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zod": "^3.25.76"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/src/contracts/citiesairContracts.sanity.ts
+++ b/src/contracts/citiesairContracts.sanity.ts
@@ -1,0 +1,34 @@
+import type { ClientInferResponseBody } from '@ts-rest/core';
+import {
+    currentContract,
+    schoolMetadataContract,
+    screenContract,
+} from '@citiesair/shared/contracts';
+
+export type CurrentSensorsContractResponse = ClientInferResponseBody<
+    typeof currentContract.getCurrentSensors,
+    200
+>;
+
+export type SchoolMetadataContractResponse = ClientInferResponseBody<
+    typeof schoolMetadataContract.getSchoolMetadata,
+    200
+>;
+
+export type ScreenContractResponse = ClientInferResponseBody<
+    typeof screenContract.getScreen,
+    200
+>;
+
+export const citiesairContractSanity = {
+    current: {
+        allSensors: currentContract.getCurrentSensors.path,
+        sensorByLocation: currentContract.getCurrentSensorByLocation.path,
+    },
+    schoolMetadata: {
+        metadata: schoolMetadataContract.getSchoolMetadata.path,
+    },
+    screen: {
+        screenData: screenContract.getScreen.path,
+    },
+} as const;


### PR DESCRIPTION
This adds a minimal frontend sanity integration for CIT-94.

What changed:
- Installs `@citiesair/shared` pinned to shared commit `2cdbf8f9b0c3355cdd79d46418ec99e169a858a3`
- Adds frontend-safe dependencies `@ts-rest/core` and `zod`
- Adds `src/contracts/citiesairContracts.sanity.ts`
- Imports `currentContract`, `schoolMetadataContract`, and `screenContract`
- Exports inferred response types using `ClientInferResponseBody`

Validation:
- `npm run typecheck` passed
- `npm run build` passed

No UI behavior changed. No components were migrated. This is only a sanity check proving the frontend can consume `@citiesair/shared/contracts`.